### PR TITLE
Update Api.php

### DIFF
--- a/Helper/Api.php
+++ b/Helper/Api.php
@@ -163,7 +163,7 @@ class Api extends AbstractHelper
             $endpoint = $debugEndpoint;
         }
 
-        $headers = ['Content-Type: application/json'];
+        $headers = ['Content-Type' => 'application/json'];
         if (null !== $token) {
             $headers[] = "Authorization: bearer $token";
         }


### PR DESCRIPTION

Using PHP 7.4.21 and M2.4.3-p2, headers must be a key-value array:
Data returned is:
"{"errors":[{"message":"Request content type must be application/json","extensions":{"category":"internal"}}]}"

And this will trigger an error on every $this->graphQlQuery($query)['data'] call as the returned result won't have any "data" value.

Propossed solution:
Change:
$headers = ['Content-Type: application/json'];
By:
$headers = ['Content-Type' => 'application/json'];